### PR TITLE
gofumpt: Run on repo

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -117,5 +117,4 @@ func TestDocker(t *testing.T) {
 	if err := di.Stop(); err == nil {
 		t.Error("Expected error trying to stop a destroyed container, instead got nil")
 	}
-
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -30,7 +30,6 @@ func (s TengoIntegrationSuite) TestIsSyntaxError(t *testing.T) {
 	_, err = db.Exec("ALTER TAABBEL actor ENGINE=InnoDB")
 	if err == nil {
 		t.Error("Bad syntax still returned nil error unexpectedly")
-
 	} else if !IsSyntaxError(err) {
 		t.Errorf("Error of type %T %+v unexpectedly not considered syntax error", err, err)
 	}

--- a/flavor_test.go
+++ b/flavor_test.go
@@ -236,7 +236,6 @@ func TestFlavorAlwaysShowTableCollation(t *testing.T) {
 			t.Errorf("Expected %s.AlwaysShowCollation(%s) to return %t, instead found %t", tc.receiver, tc.charSet, tc.expected, actual)
 		}
 	}
-
 }
 
 func TestFlavorGeneratedColumns(t *testing.T) {
@@ -313,5 +312,4 @@ func TestOmitIntDisplayWidth(t *testing.T) {
 			t.Errorf("Expected %s.OmitIntDisplayWidth() to return %t, instead found %t", tc.receiver, tc.expected, actual)
 		}
 	}
-
 }

--- a/index_test.go
+++ b/index_test.go
@@ -229,5 +229,4 @@ func TestIndexComparisonNil(t *testing.T) {
 	if idx1.RedundantTo(idx1) {
 		t.Error("Expected nil.RedundantTo(nil) to return false, but it returned true")
 	}
-
 }

--- a/introspect.go
+++ b/introspect.go
@@ -646,12 +646,12 @@ var reColumnNameFromLine = regexp.MustCompile("^\\s*`((?:[^`]|``)+)`")
 
 // This function manipulates the SHOW CREATE text to normalize some weirdness
 // from MySQL 8.0:
-// * 8.0 includes column-level character sets and collations whenever specified
-//   explicitly in the original CREATE, even when equal to the table's defaults
-// * Tables upgraded from pre-8.0 may omit COLLATE if it's the default for the
-//   charset, while tables created in 8.0 will include it
-// * 8.0.24+ uses "utf8mb3" for table-level default in place of "utf8", but
-//   doesn't do this for columns
+//   - 8.0 includes column-level character sets and collations whenever specified
+//     explicitly in the original CREATE, even when equal to the table's defaults
+//   - Tables upgraded from pre-8.0 may omit COLLATE if it's the default for the
+//     charset, while tables created in 8.0 will include it
+//   - 8.0.24+ uses "utf8mb3" for table-level default in place of "utf8", but
+//     doesn't do this for columns
 func fixShowCreateCharSets(t *Table, flavor Flavor) {
 	// Find columns with unnecessary charset+collation clause, and replace with
 	// either blank string (if collation is default for the charset) or just the


### PR DESCRIPTION
### Changed
- Run [gofumpt](https://github.com/mvdan/gofumpt) on whole repo, to reduce noise with precommit going forwards